### PR TITLE
Seva Store: Bug fix

### DIFF
--- a/seva-launcher/seva-compose.go
+++ b/seva-launcher/seva-compose.go
@@ -234,7 +234,7 @@ func is_running(command WebSocketCommand) WebSocketCommand {
 	}
 	var containers Containers
 	err = json.Unmarshal([]byte(output), &containers)
-	if err != nil {
+	if err != nil && containers != nil {
 		log.Println("Failed to parse JSON from docker-compose!")
 		exit(1)
 	}

--- a/seva-launcher/seva-websocket.go
+++ b/seva-launcher/seva-websocket.go
@@ -31,7 +31,7 @@ func websocket_controller(w http.ResponseWriter, r *http.Request) {
 		_, message, err := c.ReadMessage()
 		if err != nil {
 			log.Println("read:", err)
-			break
+			exit(1)
 		}
 		log.Printf("recv: %s", message)
 


### PR DESCRIPTION
commit b3d40cb03f356ff5838e4401c3e7ba511858f7fe (HEAD -> seva-bug-fix, tag: v1.0.3)
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Wed Oct 25 11:46:12 2023 +0530

    seva-launcher: seva-compose: Add if check
    
    - Apparently in recent version of json, the API json.Unmarshal()
    throws error when the input source is empty. Hence, make the if
    condition more concrete to avoid unnecesaary termination of seva-launcher.
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>



commit ee92bb76042c017da2b2071f3179459472c9248b
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Wed Oct 25 11:41:22 2023 +0530

    seva-launcher: seva-websocket: Kill seva-launcher binary
    
    - As Seva Store goes as a part of ti-apps-launcher, it's
    necessary to kill the seva-launcher as soon as an error is
    encountered.
    
    - This commit ensures that we don't manually press "Stop" in
    ti-apps-launcher to kill seva-launcher.
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
