### PR TITLE
seva-launcher: Remove Docker Load of Firefox

### DIFF
--- a/seva-launcher/seva-launcher.go
+++ b/seva-launcher/seva-launcher.go
@@ -21,9 +21,7 @@ import (
 var docker_browser_tag = "v1.0.0"
 var docker_browser_path = "ghcr.io/texasinstruments/seva-browser:" + docker_browser_tag
 
-// path to seva-browser.tar.gz in tisdk-default-image
-var path_to_docker_browser = "/opt/seva-browser.tar.gz"
-
+// Link to Repository which has docker-compose file for each demo 
 var store_url = "https://raw.githubusercontent.com/TexasInstruments/seva-apps/main"
 
 var addr = flag.String("addr", "0.0.0.0:8000", "http service address")
@@ -87,53 +85,10 @@ func launch_browser() {
 	}
 }
 
-// Generates a docker image for seva-browser from tar.gz
-func generate_docker_browser(args ...string) {
-	args = append([]string{"load"}, args...)
-	cmd := exec.Command("docker", args...)
-	_, err := cmd.CombinedOutput()
-
-	if err != nil {
-		log.Println("seva-browser packaged in default image didn't load, fetching one through docker")
-		return
-	}
-}
-
-// Checks if seva-browser is packaged inside tisdk-default-image
-func browser_image_present() bool {
-	_, err := os.Stat(path_to_docker_browser)
-	if os.IsNotExist(err) {
-		log.Println("seva-browser doesn't exist in default image, fetching one through docker")
-		return false
-	}
-	return true
-}
-
-// Checks if seva-browser is extracted from tar.gz to docker image
-func is_browser_loaded() bool {
-	cmd := exec.Command("docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	images := strings.Split(string(output), "\n")
-	for _, tag := range images {
-		if tag == docker_browser_path {
-			return true
-		}
-	}
-
-	return false
-}
-
 // Launches seva-browser
 func launch_docker_browser() {
 	xdg_runtime_dir := os.Getenv("XDG_RUNTIME_DIR")
 
-	if browser_image_present() && !is_browser_loaded() {
-		generate_docker_browser("--input", path_to_docker_browser)
-	}
 	output := docker_run("--rm", "--privileged", "--network", "host",
 		"-e", "XDG_RUNTIME_DIR=/tmp",
                 "-e", "DISPLAY",


### PR DESCRIPTION
- GPU accelerated Native Chromium browser is added with SDK 9.2 release [1]. Hence, the Docker based Firefox browser tarball is removed from the filesystem [2].

- Hence, Remove the logic which used to docker load the tar-ball from /opt/ as Seva Store will now launch on the GPU accelerated Native Chromium browser.

- This change will enhance the performance & user experience of Seva Store on all platforms.

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=kirkstone&id=1c7e65c70d3d0648274b9945a94dc8a3b69e5b94

[2]: https://git.ti.com/cgit/ti-sdk-linux/meta-tisdk/commit/?h=kirkstone&id=70dce5ff45bf02fd8fdcf8ef9d7fd55f5e1aa6b0