### PR TITLE
workflows: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Go package
 on:
   push:
     tags: ["v*.*.*"]
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
- The release.yml file is intended to run only when a tagged commit is pushed. 

- We have cicd.yml file which handles the build check when a PR is created on main branch [1] 
Hence, remove branches from release.yml so as to avoid running this workflow when a non-tagged commit is pushed to main.

[1]: https://github.com/TexasInstruments/seva/blob/main/.github/workflows/cicd.yml