### PR TITLE
workflows: Fix typo in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           cp seva-launcher seva-launcher-am62p-aarch64
           make clean
           make ARCH=aarch64 SOC=AM67
-          cp seva-launcher seva-launcher-am68-aarch64
+          cp seva-launcher seva-launcher-am67-aarch64
           make clean
           make ARCH=aarch64 SOC=AM68
           cp seva-launcher seva-launcher-am68-aarch64


### PR DESCRIPTION
- The seva-launcher binary name for AM67 should be seva-launcher-am67-aarch64