### PR TITLE
seva-launcher: Migrate to a different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ amd64/x86_64.
 
 Access the web interface using either:
 
-- The on device interface with `http://localhost/`
-- The remote interface with `http://<device-ip-or-hostname>/`
+- The on device interface with `http://localhost:8007/`
+- The remote interface with `http://<device-ip-or-hostname>:8007/`
 
 The store page is currently set to use the locally hosted design gallery page
 provided by the [seva-design-gallery
@@ -72,7 +72,7 @@ found, the command is ignored. If it is found then the command is send to
 seva-launcher instructing it to fetch the associated files.
 
 The result of this fetch is then relayed back to the web interface through a
-websocket at `http://localhost:8000/ws`. Seva Control Center can only interact
+websocket at `http://localhost:8007/ws`. Seva Control Center can only interact
 with seva-launcher in this manner.
 
 ### Why is this so complicated?

--- a/seva-launcher/seva-launcher.go
+++ b/seva-launcher/seva-launcher.go
@@ -24,7 +24,7 @@ var docker_browser_path = "ghcr.io/texasinstruments/seva-browser:" + docker_brow
 // Link to Repository which has docker-compose file for each demo 
 var store_url = "https://raw.githubusercontent.com/TexasInstruments/seva-apps/main"
 
-var addr = flag.String("addr", "0.0.0.0:8000", "http service address")
+var addr = flag.String("addr", "0.0.0.0:8007", "http service address")
 var no_browser = flag.Bool("no-browser", false, "do not launch browser")
 var docker_browser = flag.Bool("docker-browser", false, "force use of docker browser")
 var http_proxy = flag.String("http_proxy", "", "use to set http proxy")
@@ -77,7 +77,7 @@ func launch_browser() {
 	if *docker_browser {
 		go launch_docker_browser()
 	} else {
-		err := open.Start("http://localhost:8000/#/")
+		err := open.Start("http://localhost:8007/#/")
 		if err != nil {
 			log.Println("Host browser not detected, trying to load & launch seva-browser packaged in default image")
 			go launch_docker_browser()
@@ -99,7 +99,7 @@ func launch_docker_browser() {
 		"-v", xdg_runtime_dir+":/tmp",
 		"-u", "user",
 		"ghcr.io/texasinstruments/seva-browser:"+docker_browser_tag,
-		"http://localhost:8000/#/",
+		"http://localhost:8007/#/",
 	)
 	output_strings := strings.Split(strings.TrimSpace(string(output)), "\n")
 	container_id_list[0] = output_strings[len(output_strings)-1]

--- a/seva-web/lib/websocket.dart
+++ b/seva-web/lib/websocket.dart
@@ -7,7 +7,7 @@ import 'url_builder.dart';
 // setup the websocket
 final host_name = html.window.location.hostname;
 var channel = WebSocketChannel.connect(
-  Uri.parse('ws://${host_name}:8000/ws'),
+  Uri.parse('ws://${host_name}:8007/ws'),
 );
 Stream stream = channel.stream.asBroadcastStream();
 


### PR DESCRIPTION
- edgeai-studio-agent present in TI SDK for AM62x & AM62P uses port 8000 to stream data to the frontend tool.

- The seva-launcher also uses the same 8000 port hence causing a clash. To avoid it migrate seva-launcher to different port number.