### PR TITLE
seva-launcher: add support for docker compose v2

### DIFF
--- a/seva-launcher/seva-compose.go
+++ b/seva-launcher/seva-compose.go
@@ -41,7 +41,12 @@ type Containers []struct {
 
 func start_app(command WebSocketCommand) WebSocketCommand {
 	log.Println("Starting selected app")
+
 	cmd := exec.Command(docker_compose, "-p", "seva-launcher", "up", "-d")
+	if docker_compose == "docker" {
+		cmd = exec.Command(docker_compose, "compose", "-p", "seva-launcher", "up", "-d")
+	}
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println("Failed to start selected app!")
@@ -168,7 +173,11 @@ func apply_proxy_settings(proxy_settings ProxySettings) {
 
 func stop_app(command WebSocketCommand) WebSocketCommand {
 	log.Println("Stopping selected app")
+
 	cmd := exec.Command(docker_compose, "-p", "seva-launcher", "down", "--remove-orphans")
+	if docker_compose == "docker" {
+		cmd = exec.Command(docker_compose, "compose", "-p", "seva-launcher", "down", "--remove-orphans")
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println("Failed to stop selected app! (It may not be running!)")
@@ -226,7 +235,11 @@ func load_app(command WebSocketCommand) WebSocketCommand {
 func is_running(command WebSocketCommand) WebSocketCommand {
 	name := command.Arguments[0]
 	log.Println("Checking if " + name + " is running")
+
 	cmd := exec.Command(docker_compose, "-p", "seva-launcher", "ps", "--format", "json")
+	if docker_compose == "docker" {
+		cmd = exec.Command(docker_compose, "compose", "-p", "seva-launcher", "ps", "--format", "json")
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		log.Println("Failed to check if app is running!")

--- a/seva-launcher/seva-launcher.go
+++ b/seva-launcher/seva-launcher.go
@@ -39,25 +39,20 @@ var content embed.FS
 //go:embed docker-compose
 var docker_compose_bin []byte
 
-// Checks if docker compose is present in the file-system
-func is_docker_compose_installed() bool {
-	cmd := exec.Command("docker-compose", "-v")
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Println("Docker-compose is either not installed or cannot be executed")
-		log.Println(err)
-		log.Println("Using local install for now")
-		return false
-	}
-	return true
-}
-
 func prepare_compose() string {
-	if !is_docker_compose_installed() {
-		ioutil.WriteFile("docker-compose", docker_compose_bin, 0755)
-		return "./docker-compose"
-	}
-	return "docker-compose"
+    // Try V2 first
+    cmd := exec.Command("docker", "compose", "version")
+    if err := cmd.Run(); err == nil {
+        return "docker"
+    }
+    // Try V1
+    cmd = exec.Command("docker-compose", "-v")
+    if err := cmd.Run(); err == nil {
+        return "docker-compose"
+    }
+    // Neither installed, use bundled binary
+	ioutil.WriteFile("docker-compose", docker_compose_bin, 0755)
+	return "./docker-compose"
 }
 
 func setup_working_directory() {


### PR DESCRIPTION
Docker compose v2 is built-in to the docker command and is not a script like docker compose v1 and the command invocation also changed from docker-compose to docker compose. Patch adds this feature so that seva-laucher can work with docker compose v2.